### PR TITLE
feat(queue): add Today's Queue screen with call and availability actions

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -33,6 +33,13 @@ const routes: Routes = [
         },
       },
       {
+        path: 'queue',
+        data: {
+          breadcrumb: 'Queue'
+        },
+        loadChildren: () => import('./queue/queue.module').then(m => m.QueueModule)
+      },
+      {
         path: 'messages',
         data: {
           breadcrumb: 'Messages',

--- a/src/app/main-container/sidebar-menu-list/sidebar-menu-list.component.html
+++ b/src/app/main-container/sidebar-menu-list/sidebar-menu-list.component.html
@@ -9,6 +9,14 @@
   </li>
 </ng-container>
 
+<li class="nav-item" *ngxPermissionsExcept="['ORGANIZATIONAL: SYSTEM ADMINISTRATOR', 'ORGANIZATIONAL: NURSE', 'ORGANIZATIONAL:MCC']"
+    (click)="toggleSidebar()" data-test-id="listItemQueue">
+  <a class="nav-item-link" routerLink="/queue" routerLinkActive="active" data-test-id="linkQueue">
+    <img src="assets/svgs/menu-queue.svg" alt="" data-test-id="iconQueue">
+    <span data-test-id="labelQueue">{{'Queue' | translate}}</span>
+  </a>
+</li>
+
 <ng-container *ngIf="menus?.messages">
   <li class="nav-item"
       *ngxPermissionsExcept="['ORGANIZATIONAL: SYSTEM ADMINISTRATOR', 'ORGANIZATIONAL: NURSE', 'ORGANIZATIONAL:MCC']"

--- a/src/app/queue/modals/call-done/call-done.component.html
+++ b/src/app/queue/modals/call-done/call-done.component.html
@@ -1,0 +1,27 @@
+<div class="intel-con-modal queue-modal" data-test-id="callDoneModal">
+  <div class="queue-modal-close">
+    <button class="modal-close-btn" (click)="close(null)" data-test-id="btnCloseCallDone">
+      <img src="assets/svgs/CloseX.svg" alt="Close" />
+    </button>
+  </div>
+
+  <div class="modal-con">
+    <div class="queue-modal-icon violet">
+      <img src="assets/svgs/queue-call-done.svg" alt="" data-test-id="imgCallDone" />
+    </div>
+    <h6 class="mt-3" data-test-id="lblCallDoneTitle">{{ 'Call Marked as done' | translate }}</h6>
+    <p class="mt-2 text-center" data-test-id="lblCallDoneMessage">
+      {{ 'Complete the prescription for' | translate }} {{ data.patientName }}
+    </p>
+  </div>
+
+  <div class="modal-action-btn-con">
+    <button class="modal-btn white-btn mr-3" type="button" (click)="close('queue')" data-test-id="btnBackToQueue">
+      {{ 'Back to Queue' | translate }}
+    </button>
+    <button class="modal-btn blue-btn" type="button" (click)="close('prescription')"
+      data-test-id="btnWritePrescription">
+      {{ 'Write Prescription' | translate }}
+    </button>
+  </div>
+</div>

--- a/src/app/queue/modals/call-done/call-done.component.ts
+++ b/src/app/queue/modals/call-done/call-done.component.ts
@@ -1,0 +1,16 @@
+import { Component, Inject } from '@angular/core';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+
+@Component({
+  selector: 'app-call-done',
+  templateUrl: './call-done.component.html'
+})
+export class CallDoneComponent {
+
+  constructor(@Inject(MAT_DIALOG_DATA) public data: { patientName: string },
+    private dialogRef: MatDialogRef<CallDoneComponent>) { }
+
+  close(val: 'queue' | 'prescription' | null) {
+    this.dialogRef.close(val);
+  }
+}

--- a/src/app/queue/modals/call-not-happened/call-not-happened.component.html
+++ b/src/app/queue/modals/call-not-happened/call-not-happened.component.html
@@ -1,0 +1,37 @@
+<div class="intel-con-modal queue-modal" data-test-id="callNotHappenedModal">
+  <div class="queue-modal-close">
+    <button class="modal-close-btn" (click)="close(false)" data-test-id="btnCloseCallNotHappened">
+      <img src="assets/svgs/CloseX.svg" alt="Close" />
+    </button>
+  </div>
+
+  <div class="modal-con">
+    <div class="queue-modal-icon grey">
+      <img src="assets/svgs/queue-call-missed.svg" alt="" data-test-id="imgCallNotHappened" />
+    </div>
+    <h6 class="mt-3" data-test-id="lblCallNotHappenedTitle">{{ 'Call did not happen?' | translate }}</h6>
+    <p class="mt-2 text-center" data-test-id="lblCallNotHappenedMessage">
+      {{ 'You can continue with a prescription without a call.' | translate }}
+    </p>
+  </div>
+
+  <div class="reason-list">
+    <label *ngFor="let reason of reasons" class="reason-option" [class.selected]="selectedReason === reason"
+      [attr.data-test-id]="'optReason' + reason">
+      <input type="radio" name="callNotHappenedReason" [value]="reason" [(ngModel)]="selectedReason" />
+      <span class="radio-dot"></span>
+      <span class="reason-label">{{ reason | translate }}</span>
+    </label>
+  </div>
+
+  <div class="modal-action-btn-con">
+    <button class="modal-btn white-btn mr-3" type="button" (click)="close(false)"
+      data-test-id="btnCancelCallNotHappened">
+      {{ 'Cancel' | translate }}
+    </button>
+    <button class="modal-btn blue-btn" type="button" [disabled]="!selectedReason" (click)="close(true)"
+      data-test-id="btnContinueCallNotHappened">
+      {{ 'Continue' | translate }}
+    </button>
+  </div>
+</div>

--- a/src/app/queue/modals/call-not-happened/call-not-happened.component.ts
+++ b/src/app/queue/modals/call-not-happened/call-not-happened.component.ts
@@ -1,0 +1,20 @@
+import { Component } from '@angular/core';
+import { MatDialogRef } from '@angular/material/dialog';
+import { CALL_NOT_HAPPENED_REASONS } from '../../queue.model';
+
+@Component({
+  selector: 'app-call-not-happened',
+  templateUrl: './call-not-happened.component.html'
+})
+export class CallNotHappenedComponent {
+
+  reasons = CALL_NOT_HAPPENED_REASONS;
+  selectedReason: string | null = null;
+
+  constructor(private dialogRef: MatDialogRef<CallNotHappenedComponent>) { }
+
+
+  close(confirmed: boolean) {
+    this.dialogRef.close(confirmed ? this.selectedReason : null);
+  }
+}

--- a/src/app/queue/modals/end-shift/end-shift.component.html
+++ b/src/app/queue/modals/end-shift/end-shift.component.html
@@ -1,0 +1,26 @@
+<div class="intel-con-modal queue-modal" data-test-id="endShiftModal">
+  <div class="queue-modal-close">
+    <button class="modal-close-btn" (click)="close(false)" data-test-id="btnCloseEndShift">
+      <img src="assets/svgs/CloseX.svg" alt="Close" />
+    </button>
+  </div>
+
+  <div class="modal-con">
+    <div class="queue-modal-icon grey">
+      <img src="assets/svgs/queue-end-shift.svg" alt="" data-test-id="imgEndShift" />
+    </div>
+    <h6 class="mt-3" data-test-id="lblEndShiftTitle">{{ 'End Shift for today?' | translate }}</h6>
+    <p class="mt-2 text-center" data-test-id="lblEndShiftMessage">
+      {{ 'Healthworkers will see that you are unavailable. You will not receive new consultations today.' | translate }}
+    </p>
+  </div>
+
+  <div class="modal-action-btn-con">
+    <button class="modal-btn white-btn mr-3" type="button" (click)="close(false)" data-test-id="btnCancelEndShift">
+      {{ 'Cancel' | translate }}
+    </button>
+    <button class="modal-btn dark-btn" type="button" (click)="close(true)" data-test-id="btnConfirmEndShift">
+      {{ 'Log Off' | translate }}
+    </button>
+  </div>
+</div>

--- a/src/app/queue/modals/end-shift/end-shift.component.ts
+++ b/src/app/queue/modals/end-shift/end-shift.component.ts
@@ -1,0 +1,15 @@
+import { Component } from '@angular/core';
+import { MatDialogRef } from '@angular/material/dialog';
+
+@Component({
+  selector: 'app-end-shift',
+  templateUrl: './end-shift.component.html'
+})
+export class EndShiftComponent {
+
+  constructor(private dialogRef: MatDialogRef<EndShiftComponent>) { }
+
+  close(val: boolean) {
+    this.dialogRef.close(val);
+  }
+}

--- a/src/app/queue/modals/pause-queue/pause-queue.component.html
+++ b/src/app/queue/modals/pause-queue/pause-queue.component.html
@@ -1,0 +1,39 @@
+<div class="intel-con-modal queue-modal" data-test-id="pauseQueueModal">
+  <div class="queue-modal-close">
+    <button class="modal-close-btn" (click)="close(false)" data-test-id="btnClosePauseQueue">
+      <img src="assets/svgs/CloseX.svg" alt="Close" />
+    </button>
+  </div>
+
+  <div class="modal-con">
+    <div class="queue-modal-icon orange">
+      <img src="assets/svgs/queue-break.svg" alt="" data-test-id="imgPauseQueue" />
+    </div>
+    <h6 class="mt-3" data-test-id="lblPauseQueueTitle">{{ 'Pause Queue?' | translate }}</h6>
+    <p class="mt-2 text-center" data-test-id="lblPauseQueueMessage">
+      {{ 'Patients will see updated wait times while you are away.' | translate }}
+    </p>
+  </div>
+
+  <div class="preset-row">
+    <button *ngFor="let preset of presets" type="button" class="preset-btn"
+      [class.selected]="selectedPreset === preset" (click)="selectPreset(preset)"
+      [attr.data-test-id]="'btnPreset' + preset">
+      {{ preset }} {{ 'min' | translate }}
+    </button>
+  </div>
+
+  <input class="custom-duration-input" type="number" min="1" [(ngModel)]="customDuration"
+    (ngModelChange)="onCustomDurationChange()" [placeholder]="'Custom duration (minutes)' | translate"
+    data-test-id="inputCustomDuration" />
+
+  <div class="modal-action-btn-con">
+    <button class="modal-btn white-btn mr-3" type="button" (click)="close(false)" data-test-id="btnCancelPauseQueue">
+      {{ 'Cancel' | translate }}
+    </button>
+    <button class="modal-btn blue-btn" type="button" [disabled]="!duration" (click)="close(true)"
+      data-test-id="btnConfirmBreak">
+      {{ 'Confirm Break' | translate }}
+    </button>
+  </div>
+</div>

--- a/src/app/queue/modals/pause-queue/pause-queue.component.ts
+++ b/src/app/queue/modals/pause-queue/pause-queue.component.ts
@@ -1,0 +1,43 @@
+import { Component } from '@angular/core';
+import { MatDialogRef } from '@angular/material/dialog';
+import { BREAK_PRESETS } from '../../queue.model';
+
+@Component({
+  selector: 'app-pause-queue',
+  templateUrl: './pause-queue.component.html'
+})
+export class PauseQueueComponent {
+
+  presets = BREAK_PRESETS;
+  selectedPreset: number | null = 20;
+  customDuration: number | null = null;
+
+  constructor(private dialogRef: MatDialogRef<PauseQueueComponent>) { }
+
+
+  selectPreset(minutes: number) {
+    this.selectedPreset = minutes;
+    this.customDuration = null;
+  }
+
+
+  onCustomDurationChange() {
+    if (this.customDuration !== null && `${this.customDuration}` !== '') {
+      this.selectedPreset = null;
+    }
+  }
+
+  
+  get duration(): number | null {
+    const custom = Number(this.customDuration);
+    if (custom > 0) {
+      return custom;
+    }
+    return this.selectedPreset;
+  }
+
+ 
+  close(confirmed: boolean) {
+    this.dialogRef.close(confirmed ? this.duration : null);
+  }
+}

--- a/src/app/queue/queue-modals.scss
+++ b/src/app/queue/queue-modals.scss
@@ -1,0 +1,232 @@
+/* Queue dialogs and row menu render in the CDK overlay, outside the
+   QueueComponent's view, so their styles must be global. */
+
+$q-violet: #2E1B87;
+$q-violet-text: #3B23A8;
+$q-violet-soft: #EDEAFB;
+$q-slate: #37415B;
+$q-ink: #2B2B4B;
+$q-muted: #7F7B92;
+$q-border: #E6E6EF;
+
+.queue-modal-panel {
+  .mat-dialog-container {
+    border-radius: 16px;
+    padding: 0;
+  }
+
+  .queue-modal {
+    padding: 24px;
+    width: 100%;
+
+    .queue-modal-close {
+      width: 100%;
+      display: flex;
+      justify-content: flex-end;
+
+      .modal-close-btn {
+        display: inline-flex;
+        align-items: center;
+        border: none;
+        background: transparent;
+        outline: none;
+        padding: 0;
+      }
+    }
+
+    .queue-modal-icon {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      width: 80px;
+      height: 80px;
+      border-radius: 50%;
+
+      &.grey {
+        background: #F2F3F7;
+      }
+
+      &.orange {
+        background: #FDEFE0;
+      }
+
+      &.violet {
+        background: $q-violet-soft;
+      }
+    }
+
+    .modal-con {
+      h6 {
+        color: $q-ink;
+      }
+    }
+
+    .modal-action-btn-con {
+      width: 100%;
+      margin-top: 24px;
+
+      .modal-btn {
+        flex: 1;
+        border: 1px solid $q-violet-soft;
+        color: $q-violet-text;
+
+        &:disabled {
+          opacity: .5;
+          cursor: not-allowed;
+        }
+      }
+
+      .modal-btn.blue-btn {
+        background: $q-violet;
+        border: 1px solid $q-violet;
+        color: #FFFFFF;
+      }
+
+      .modal-btn.dark-btn {
+        background: $q-slate;
+        border: 1px solid $q-slate;
+        color: #FFFFFF;
+      }
+    }
+  }
+
+  .preset-row {
+    display: flex;
+    gap: 12px;
+    width: 100%;
+    margin-top: 24px;
+
+    .preset-btn {
+      flex: 1;
+      min-height: 48px;
+      border: 1px solid $q-border;
+      border-radius: 8px;
+      background: #FFFFFF;
+      color: $q-ink;
+      font-size: 16px;
+      font-weight: 700;
+      cursor: pointer;
+
+      &.selected {
+        background: $q-violet;
+        border-color: $q-violet;
+        color: #FFFFFF;
+      }
+    }
+  }
+
+  .custom-duration-input {
+    width: 100%;
+    min-height: 56px;
+    margin-top: 12px;
+    padding: 0 16px;
+    border: 1px solid $q-border;
+    border-radius: 8px;
+    font-size: 16px;
+    color: $q-ink;
+    outline: none;
+
+    &::placeholder {
+      color: #A5A2B3;
+    }
+
+    &:focus {
+      border-color: $q-violet;
+    }
+  }
+
+  .reason-list {
+    width: 100%;
+    margin-top: 24px;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+
+    .reason-option {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      margin: 0;
+      padding: 14px 16px;
+      border: 1px solid $q-border;
+      border-radius: 8px;
+      cursor: pointer;
+
+      input[type="radio"] {
+        position: absolute;
+        opacity: 0;
+        width: 0;
+        height: 0;
+      }
+
+      .radio-dot {
+        width: 20px;
+        height: 20px;
+        border: 1.5px solid #C9C7D4;
+        border-radius: 50%;
+        flex-shrink: 0;
+        position: relative;
+      }
+
+      .reason-label {
+        font-size: 16px;
+        color: $q-muted;
+      }
+
+      &.selected {
+        border-color: $q-violet;
+
+        .radio-dot {
+          border-color: $q-violet;
+
+          &::after {
+            content: '';
+            position: absolute;
+            inset: 3px;
+            border-radius: 50%;
+            background: $q-violet;
+          }
+        }
+
+        .reason-label {
+          color: $q-ink;
+          font-weight: 600;
+        }
+      }
+    }
+  }
+}
+
+.queue-row-menu.mat-menu-panel {
+  min-width: 240px;
+  border-radius: 12px;
+  box-shadow: 0 8px 24px rgba(43, 43, 75, .12);
+
+  .mat-menu-content {
+    padding: 6px 0;
+  }
+
+  .mat-menu-item {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    height: 44px;
+    line-height: 44px;
+    font-size: 15px;
+    color: $q-ink;
+
+    img {
+      width: 18px;
+      height: 18px;
+    }
+
+    &.accent {
+      color: $q-violet;
+      font-weight: 600;
+    }
+
+    & + .mat-menu-item {
+      border-top: 1px solid #F2F2F7;
+    }
+  }
+}

--- a/src/app/queue/queue-routing.module.ts
+++ b/src/app/queue/queue-routing.module.ts
@@ -1,0 +1,16 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+import { QueueComponent } from './queue.component';
+
+const routes: Routes = [
+  {
+    path: '',
+    component: QueueComponent
+  }
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule]
+})
+export class QueueRoutingModule { }

--- a/src/app/queue/queue.component.html
+++ b/src/app/queue/queue.component.html
@@ -1,0 +1,148 @@
+<div class="queue-page" data-test-id="queuePage">
+
+  <div class="queue-page-header">
+    <div class="greeting-con">
+      <span class="greeting" data-test-id="lblGreeting">{{ greeting | translate }}</span>
+      <h4 class="doctor-name" data-test-id="lblDoctorName">{{ doctorName }}</h4>
+    </div>
+
+    <div class="availability-toggle" data-test-id="availabilityToggle">
+      <button type="button" class="availability-btn available" [class.active]="availability === 'available'"
+        (click)="setAvailable()" [matTooltip]="'Available' | translate" data-test-id="btnAvailable">
+        <img src="assets/svgs/queue-available.svg" alt="" />
+      </button>
+      <button type="button" class="availability-btn break" [class.active]="availability === 'on_break'"
+        (click)="openPauseQueue()" [matTooltip]="'Take a break' | translate" data-test-id="btnTakeBreak">
+        <img src="assets/svgs/queue-break.svg" alt="" />
+      </button>
+      <button type="button" class="availability-btn off-shift" [class.active]="availability === 'off_shift'"
+        (click)="openEndShift()" [matTooltip]="'End shift' | translate" data-test-id="btnEndShift">
+        <img src="assets/svgs/queue-end-shift.svg" alt="" />
+      </button>
+    </div>
+  </div>
+
+  <div class="break-banner" *ngIf="availability === 'on_break' && breakEndsAt" data-test-id="breakBanner">
+    {{ 'Queue paused until' | translate }} {{ breakEndsAt | date: 'shortTime' }}
+  </div>
+
+  <div class="queue-card">
+    <div class="queue-card-header">
+      <span class="queue-card-icon">
+        <img src="assets/svgs/menu-queue.svg" alt="" />
+      </span>
+      <h5 class="queue-card-title" data-test-id="lblQueueTitle">{{ "Today's Queue" | translate }}</h5>
+      <img class="info-icon" src="assets/svgs/menu-info.svg" alt=""
+        [matTooltip]="'Patients waiting for a consultation today' | translate" />
+    </div>
+
+    <div class="queue-table-con">
+      <table mat-table [dataSource]="pagedPatients" matTableResponsive class="queue-table"
+        data-test-id="tableTodaysQueue">
+
+        <ng-container matColumnDef="patient">
+          <th mat-header-cell *matHeaderCellDef>{{ 'Patient' | translate }}</th>
+          <td mat-cell *matCellDef="let row">
+            <div class="patient-cell">
+              <img class="patient-avatar" src="assets/svgs/user.svg" alt="" />
+              <span class="patient-name" [matTooltip]="row.name">{{ row.name }} ({{ row.gender }})</span>
+            </div>
+          </td>
+        </ng-container>
+
+        <ng-container matColumnDef="age">
+          <th mat-header-cell *matHeaderCellDef>{{ 'Age' | translate }}</th>
+          <td mat-cell *matCellDef="let row">{{ row.age }}</td>
+        </ng-container>
+
+        <ng-container matColumnDef="status">
+          <th mat-header-cell *matHeaderCellDef>{{ 'Status' | translate }}</th>
+          <td mat-cell *matCellDef="let row">
+            <span class="status-chip" [ngClass]="statusClass(row.status)">
+              {{ statusLabels[row.status] | translate }}
+            </span>
+          </td>
+        </ng-container>
+
+        <ng-container matColumnDef="hw">
+          <th mat-header-cell *matHeaderCellDef>{{ 'HW' | translate }}</th>
+          <td mat-cell *matCellDef="let row">{{ row.hw }}</td>
+        </ng-container>
+
+        <ng-container matColumnDef="location">
+          <th mat-header-cell *matHeaderCellDef>{{ 'Location' | translate }}</th>
+          <td mat-cell *matCellDef="let row">{{ row.location }}</td>
+        </ng-container>
+
+        <ng-container matColumnDef="chiefComplaint">
+          <th mat-header-cell *matHeaderCellDef>{{ 'Chief complaint' | translate }}</th>
+          <td mat-cell *matCellDef="let row" class="complaint-cell">{{ row.chiefComplaint }}</td>
+        </ng-container>
+
+        <ng-container matColumnDef="actions">
+          <th mat-header-cell *matHeaderCellDef>{{ 'Actions' | translate }}</th>
+          <td mat-cell *matCellDef="let row">
+            <div class="actions-cell">
+              <button type="button" class="row-btn ghost-btn" (click)="viewSummary(row)"
+                data-test-id="btnViewSummary">
+                {{ 'View Summary' | translate }}
+              </button>
+
+              <button type="button" class="row-btn primary-btn" *ngIf="row.status === 'on_call'"
+                (click)="startCall(row)" data-test-id="btnStartCall">
+                <img src="assets/svgs/video-w.svg" alt="" />
+                {{ 'Start' | translate }}
+              </button>
+
+              <button type="button" class="kebab-btn" [matMenuTriggerFor]="rowMenu"
+                (click)="$event.stopPropagation()" data-test-id="btnRowMenu">
+                <mat-icon>more_vert</mat-icon>
+              </button>
+
+              <mat-menu #rowMenu="matMenu" class="queue-row-menu" xPosition="before">
+                <button mat-menu-item (click)="viewSummary(row)" data-test-id="menuViewDetails">
+                  <img src="assets/svgs/menu-treatment.svg" alt="" />
+                  <span>{{ 'View Details' | translate }}</span>
+                </button>
+                <button mat-menu-item class="accent" (click)="markCallDone(row)" data-test-id="menuMarkCallDone">
+                  <img src="assets/svgs/queue-call-done.svg" alt="" />
+                  <span>{{ 'Mark Call Done' | translate }}</span>
+                </button>
+                <button mat-menu-item (click)="markCallDidNotHappen(row)" data-test-id="menuMarkCallNotDone">
+                  <img src="assets/svgs/queue-call-missed.svg" alt="" />
+                  <span>{{ 'Mark Call Did Not Happen' | translate }}</span>
+                </button>
+              </mat-menu>
+            </div>
+          </td>
+        </ng-container>
+
+        <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+        <tr mat-row *matRowDef="let row; columns: displayedColumns"
+          [class.on-call-row]="row.status === 'on_call'"></tr>
+      </table>
+
+      <p class="no-records" *ngIf="!allPatients.length" data-test-id="lblNoQueueRecords">
+        {{ 'No patients in the queue right now.' | translate }}
+      </p>
+    </div>
+
+    <div class="queue-pager" *ngIf="allPatients.length" data-test-id="queuePager">
+      <span class="pager-count" data-test-id="lblPagerCount">
+        {{ pagedPatients.length }} {{ 'of' | translate }} {{ allPatients.length }} {{ 'Patient' | translate }}
+      </span>
+      <button type="button" class="pager-arrow" [disabled]="pageIndex === 0" (click)="goToPage(pageIndex - 1)"
+        data-test-id="btnPrevPage">
+        <mat-icon>chevron_left</mat-icon>
+      </button>
+      <button type="button" class="pager-page" *ngFor="let page of pageNumbers" [class.active]="page === pageIndex"
+        (click)="goToPage(page)" [attr.data-test-id]="'btnPage' + (page + 1)">
+        {{ page + 1 }}
+      </button>
+      <button type="button" class="pager-arrow" [disabled]="pageIndex === totalPages - 1"
+        (click)="goToPage(pageIndex + 1)" data-test-id="btnNextPage">
+        <mat-icon>chevron_right</mat-icon>
+      </button>
+    </div>
+  </div>
+</div>

--- a/src/app/queue/queue.component.scss
+++ b/src/app/queue/queue.component.scss
@@ -1,0 +1,346 @@
+$violet: #2E1B87;
+$violet-text: #3B23A8;
+$violet-soft: #EDEAFB;
+$violet-soft-hover: #E1DCF7;
+$violet-hover: #3A25A3;
+$ink: #2B2B4B;
+$muted: #7F7B92;
+$border: #EDEDF2;
+$green: #12A05C;
+$green-soft: #E6F9EF;
+$orange: #F0964B;
+$orange-soft: #FDEFE0;
+
+.queue-page {
+  padding: 8px 4px 32px;
+}
+
+.queue-page-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
+  margin-bottom: 16px;
+
+  .greeting {
+    font-size: 14px;
+    color: $muted;
+  }
+
+  .doctor-name {
+    margin: 2px 0 0;
+    font-size: 24px;
+    font-weight: 700;
+    color: $ink;
+  }
+}
+
+.availability-toggle {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 6px;
+  background: #fff;
+  border: 1px solid $border;
+  border-radius: 12px;
+
+  .availability-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 40px;
+    height: 40px;
+    padding: 0;
+    border: 1px solid transparent;
+    border-radius: 10px;
+    background: transparent;
+    color: $muted;
+    cursor: pointer;
+    transition: background-color .15s ease, border-color .15s ease;
+
+    img {
+      width: 20px;
+      height: 20px;
+    }
+
+    &:hover {
+      background: #F6F6FA;
+    }
+
+    &.available.active {
+      background: $green-soft;
+      border-color: rgba($green, .35);
+      color: $green;
+    }
+
+    &.break.active {
+      background: $orange-soft;
+      border-color: rgba($orange, .35);
+    }
+
+    &.off-shift.active {
+      background: #F1F2F6;
+      border-color: #D8DAE3;
+    }
+  }
+}
+
+.break-banner {
+  margin-bottom: 16px;
+  padding: 10px 16px;
+  border-radius: 10px;
+  background: $orange-soft;
+  color: #9A5A17;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.queue-card {
+  background: #fff;
+  border: 1px solid $border;
+  border-radius: 16px;
+  padding: 20px 20px 8px;
+  box-shadow: 0 2px 12px rgba(43, 43, 75, .05);
+}
+
+.queue-card-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 16px;
+
+  .queue-card-icon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 40px;
+    height: 40px;
+    border-radius: 10px;
+    background: $violet;
+  }
+
+  .queue-card-title {
+    margin: 0;
+    font-size: 18px;
+    font-weight: 700;
+    color: $ink;
+  }
+
+  .info-icon {
+    width: 16px;
+    height: 16px;
+    opacity: .5;
+    cursor: pointer;
+  }
+}
+
+.queue-table-con {
+  width: 100%;
+  overflow-x: auto;
+}
+
+.queue-table {
+  width: 100%;
+  background: transparent;
+
+  th.mat-header-cell {
+    padding: 12px 16px;
+    border-bottom: 1px solid $border;
+    color: $muted;
+    font-size: 13px;
+    font-weight: 500;
+    white-space: nowrap;
+  }
+
+  td.mat-cell {
+    padding: 14px 16px;
+    border-bottom: 1px solid $border;
+    color: $ink;
+    font-size: 14px;
+    font-weight: 600;
+  }
+
+  tr.mat-row {
+    &:nth-child(even) {
+      background: #FAFAFC;
+    }
+
+    &.on-call-row {
+      background: $green-soft;
+    }
+  }
+}
+
+.patient-cell {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 180px;
+
+  .patient-avatar {
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    object-fit: cover;
+    background: #EFEFF5;
+    flex-shrink: 0;
+  }
+
+  .patient-name {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    max-width: 150px;
+  }
+}
+
+.complaint-cell {
+  max-width: 180px;
+  white-space: normal;
+}
+
+.status-chip {
+  font-size: 13px;
+  font-weight: 700;
+  white-space: nowrap;
+
+  &.status-on-call {
+    color: $green;
+  }
+
+  &.status-next-in-queue {
+    color: $orange;
+  }
+
+  &.status-waiting {
+    color: $muted;
+    font-weight: 500;
+  }
+
+  &.status-completed {
+    color: $violet;
+  }
+}
+
+.actions-cell {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.row-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 14px;
+  border: none;
+  border-radius: 8px;
+  font-size: 13px;
+  font-weight: 600;
+  white-space: nowrap;
+  cursor: pointer;
+
+  img {
+    width: 16px;
+    height: 16px;
+  }
+
+  &.ghost-btn {
+    background: $violet-soft;
+    color: $violet-text;
+
+    &:hover {
+      background: $violet-soft-hover;
+    }
+  }
+
+  &.primary-btn {
+    background: $violet;
+    color: #fff;
+
+    &:hover {
+      background: $violet-hover;
+    }
+  }
+}
+
+.kebab-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  border: none;
+  border-radius: 8px;
+  background: transparent;
+  color: $muted;
+  cursor: pointer;
+
+  &:hover {
+    background: #F1F1F6;
+  }
+}
+
+.queue-pager {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 6px;
+  padding: 16px 4px;
+
+  .pager-count {
+    margin-right: 12px;
+    color: $ink;
+    font-size: 14px;
+    font-weight: 600;
+  }
+
+  .pager-arrow,
+  .pager-page {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 32px;
+    height: 32px;
+    padding: 0 6px;
+    border: none;
+    border-radius: 8px;
+    background: transparent;
+    color: $muted;
+    font-size: 14px;
+    font-weight: 600;
+    cursor: pointer;
+
+    &:hover:not(:disabled) {
+      background: #F1F1F6;
+    }
+
+    &:disabled {
+      opacity: .35;
+      cursor: default;
+    }
+  }
+
+  .pager-page.active {
+    background: $violet-soft;
+    color: $violet-text;
+  }
+}
+
+.no-records {
+  padding: 32px 0;
+  text-align: center;
+  color: $muted;
+}
+
+@media (max-width: 767px) {
+  .queue-page-header {
+    align-items: flex-start;
+  }
+
+  .actions-cell {
+    justify-content: flex-end;
+  }
+}

--- a/src/app/queue/queue.component.ts
+++ b/src/app/queue/queue.component.ts
@@ -1,0 +1,217 @@
+import { Component, OnInit } from '@angular/core';
+import { MatDialog } from '@angular/material/dialog';
+import { Router } from '@angular/router';
+import { EndShiftComponent } from './modals/end-shift/end-shift.component';
+import { PauseQueueComponent } from './modals/pause-queue/pause-queue.component';
+import { CallNotHappenedComponent } from './modals/call-not-happened/call-not-happened.component';
+import { CallDoneComponent } from './modals/call-done/call-done.component';
+import { DoctorAvailability, QueuePatient, QueueStatus, QUEUE_STATUS_LABELS } from './queue.model';
+import { getCacheData } from '../utils/utility-functions';
+import { doctorDetails } from 'src/config/constant';
+
+const MOCK_QUEUE: QueuePatient[] = [
+  { visitUuid: 'v1', patientUuid: 'p1', name: 'Suresh Deshmukh', gender: 'F', age: '24y', status: 'on_call', hw: 'Priya', location: 'TM Clinic 1', chiefComplaint: 'Fever' },
+  { visitUuid: 'v2', patientUuid: 'p2', name: 'Aman Sharma', gender: 'M', age: '18y', status: 'next_in_queue', hw: 'Ramesh', location: 'TM Clinic 2', chiefComplaint: 'Fever & Cough' },
+  { visitUuid: 'v3', patientUuid: 'p3', name: 'Suresh Deshmane', gender: 'M', age: '12d 6h', status: 'waiting', hw: 'Dipali', location: 'TM Clinic 1', chiefComplaint: 'Fever, Headache & Cough' },
+  { visitUuid: 'v4', patientUuid: 'p4', name: 'Nikita Agrawal', gender: 'F', age: '48y', status: 'waiting', hw: 'Jitesh', location: 'TM Clinic 3', chiefComplaint: 'Back pain' },
+  { visitUuid: 'v5', patientUuid: 'p5', name: 'Nitin Wagh', gender: 'M', age: '18m 15d', status: 'waiting', hw: 'Manda', location: 'TM Clinic 2', chiefComplaint: 'Runny nose' },
+  { visitUuid: 'v1', patientUuid: 'p1', name: 'Suresh Deshmukh', gender: 'F', age: '24y', status: 'on_call', hw: 'Priya', location: 'TM Clinic 1', chiefComplaint: 'Fever' },
+  { visitUuid: 'v2', patientUuid: 'p2', name: 'Aman Sharma', gender: 'M', age: '18y', status: 'next_in_queue', hw: 'Ramesh', location: 'TM Clinic 2', chiefComplaint: 'Fever & Cough' },
+  { visitUuid: 'v3', patientUuid: 'p3', name: 'Suresh Deshmane', gender: 'M', age: '12d 6h', status: 'waiting', hw: 'Dipali', location: 'TM Clinic 1', chiefComplaint: 'Fever, Headache & Cough' },
+  { visitUuid: 'v4', patientUuid: 'p4', name: 'Nikita Agrawal', gender: 'F', age: '48y', status: 'waiting', hw: 'Jitesh', location: 'TM Clinic 3', chiefComplaint: 'Back pain' },
+  { visitUuid: 'v5', patientUuid: 'p5', name: 'Nitin Wagh', gender: 'M', age: '18m 15d', status: 'waiting', hw: 'Manda', location: 'TM Clinic 2', chiefComplaint: 'Runny nose' }
+];
+
+@Component({
+  selector: 'app-queue',
+  templateUrl: './queue.component.html',
+  styleUrls: ['./queue.component.scss']
+})
+export class QueueComponent implements OnInit {
+
+  displayedColumns: string[] = ['patient', 'age', 'status', 'hw', 'location', 'chiefComplaint', 'actions'];
+  statusLabels = QUEUE_STATUS_LABELS;
+
+  allPatients: QueuePatient[] = [];
+  availability: DoctorAvailability = 'available';
+
+  breakEndsAt: Date | null = null;
+
+  pageIndex = 0;
+  pageSize = 5;
+
+  constructor(private dialog: MatDialog, private router: Router) { }
+
+  ngOnInit(): void {
+    this.loadQueue();
+  }
+
+  /**
+  * Time-of-day greeting shown above the doctor's name
+  * @return {string}
+  */
+  get greeting(): string {
+    const hour = new Date().getHours();
+    if (hour < 12) {
+      return 'Good Morning';
+    }
+    return hour < 17 ? 'Good Afternoon' : 'Good Evening';
+  }
+
+  /**
+  * Logged-in doctor's display name
+  * @return {string}
+  */
+  get doctorName(): string {
+    return getCacheData(true, doctorDetails.PROVIDER)?.person?.display ?? '';
+  }
+
+  /**
+  * Load today's queue.
+  * @return {void}
+  */
+  loadQueue(): void {
+    this.allPatients = MOCK_QUEUE;
+    this.pageIndex = 0;
+  }
+
+  /**
+  * Rows visible on the current page
+  * @return {QueuePatient[]}
+  */
+  get pagedPatients(): QueuePatient[] {
+    const start = this.pageIndex * this.pageSize;
+    return this.allPatients.slice(start, start + this.pageSize);
+  }
+
+  /**
+  * Total number of pages, at least 1 so the pager always renders
+  * @return {number}
+  */
+  get totalPages(): number {
+    return Math.max(1, Math.ceil(this.allPatients.length / this.pageSize));
+  }
+
+  /**
+  * Page numbers for the numbered pager
+  * @return {number[]}
+  */
+  get pageNumbers(): number[] {
+    return Array.from({ length: this.totalPages }, (_, i) => i);
+  }
+
+  /**
+  * Move to a page, ignoring out-of-range requests
+  * @param {number} page - Zero-based page index
+  * @return {void}
+  */
+  goToPage(page: number): void {
+    if (page < 0 || page >= this.totalPages) {
+      return;
+    }
+    this.pageIndex = page;
+  }
+
+  /**
+  * CSS modifier for a status chip
+  * @param {QueueStatus} status - Row status
+  * @return {string}
+  */
+  statusClass(status: QueueStatus): string {
+    return `status-${status.replace(/_/g, '-')}`;
+  }
+
+  /**
+  * Set the doctor as available, cancelling any active break
+  * @return {void}
+  */
+  setAvailable(): void {
+    this.availability = 'available';
+    this.breakEndsAt = null;
+  }
+
+  /**
+  * Ask for a break duration and pause the queue
+  * @return {void}
+  */
+  openPauseQueue(): void {
+    this.dialog.open(PauseQueueComponent, { panelClass: ['modal-md', 'queue-modal-panel'], width: '520px', hasBackdrop: true, disableClose: true })
+      .afterClosed().subscribe((minutes: number | null) => {
+        if (!minutes) {
+          return;
+        }
+        this.availability = 'on_break';
+        this.breakEndsAt = new Date(Date.now() + minutes * 60 * 1000);
+      });
+  }
+
+  /**
+  * Confirm and end the shift for the day
+  * @return {void}
+  */
+  openEndShift(): void {
+    this.dialog.open(EndShiftComponent, { panelClass: ['modal-md', 'queue-modal-panel'], width: '520px', hasBackdrop: true, disableClose: true })
+      .afterClosed().subscribe((confirmed: boolean) => {
+        if (!confirmed) {
+          return;
+        }
+        this.availability = 'off_shift';
+        this.breakEndsAt = null;
+      });
+  }
+
+  /**
+  * Open the visit summary for a patient
+  * @param {QueuePatient} patient - Selected row
+  * @return {void}
+  */
+  viewSummary(patient: QueuePatient): void {
+    this.router.navigate(['/dashboard', 'visit-summary', patient.visitUuid]);
+  }
+
+  /**
+  * Start the consultation for a patient
+  * @param {QueuePatient} patient - Selected row
+  * @return {void}
+  */
+  startCall(patient: QueuePatient): void {
+    this.router.navigate(['/dashboard', 'visit-summary', patient.visitUuid]);
+  }
+
+  /**
+  * Mark a call as done and offer to write the prescription
+  * @param {QueuePatient} patient - Selected row
+  * @return {void}
+  */
+  markCallDone(patient: QueuePatient): void {
+    this.dialog.open(CallDoneComponent, {
+      panelClass: ['modal-md', 'queue-modal-panel'],
+      width: '520px',
+      data: { patientName: patient.name }
+    }).afterClosed().subscribe((action: 'queue' | 'prescription' | null) => {
+      if (!action) {
+        return;
+      }
+      patient.status = 'completed';
+      if (action === 'prescription') {
+        this.router.navigate(['/dashboard', 'visit-summary', patient.visitUuid]);
+      }
+    });
+  }
+
+  /**
+  * Capture why a call did not happen and continue to the prescription
+  * @param {QueuePatient} patient - Selected row
+  * @return {void}
+  */
+  markCallDidNotHappen(patient: QueuePatient): void {
+    this.dialog.open(CallNotHappenedComponent, { panelClass: ['modal-md', 'queue-modal-panel'], width: '520px', hasBackdrop: true, disableClose: true })
+      .afterClosed().subscribe((reason: string | null) => {
+        if (!reason) {
+          return;
+        }
+        patient.status = 'completed';
+        this.router.navigate(['/dashboard', 'visit-summary', patient.visitUuid]);
+      });
+  }
+}

--- a/src/app/queue/queue.model.ts
+++ b/src/app/queue/queue.model.ts
@@ -1,0 +1,33 @@
+export type QueueStatus = 'on_call' | 'next_in_queue' | 'waiting' | 'completed';
+
+export interface QueuePatient {
+  visitUuid: string;
+  patientUuid: string;
+  name: string;
+  gender: 'M' | 'F' | 'O';
+  age: string;
+  status: QueueStatus;
+  hw: string;
+  location: string;
+  chiefComplaint: string;
+}
+
+export type DoctorAvailability = 'available' | 'on_break' | 'off_shift';
+
+export const CALL_NOT_HAPPENED_REASONS: string[] = [
+  'Async Consultation',
+  'Follow-up Case',
+  'Network Issue',
+  'Healthworker Unavailable',
+  'Patient Unavailable',
+  'Other'
+];
+
+export const BREAK_PRESETS: number[] = [10, 20, 30];
+
+export const QUEUE_STATUS_LABELS: Record<QueueStatus, string> = {
+  on_call: 'On Call',
+  next_in_queue: 'Next in Queue',
+  waiting: 'Waiting',
+  completed: 'Completed'
+};

--- a/src/app/queue/queue.module.ts
+++ b/src/app/queue/queue.module.ts
@@ -1,0 +1,55 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { HttpClient } from '@angular/common/http';
+import { MatTableModule } from '@angular/material/table';
+import { MatMenuModule } from '@angular/material/menu';
+import { MatIconModule } from '@angular/material/icon';
+import { MatDialogModule } from '@angular/material/dialog';
+import { MatTooltipModule } from '@angular/material/tooltip';
+import { MatButtonModule } from '@angular/material/button';
+import { TranslateModule, TranslateLoader } from '@ngx-translate/core';
+import { TranslateHttpLoader } from '@ngx-translate/http-loader';
+
+import { QueueRoutingModule } from './queue-routing.module';
+import { QueueComponent } from './queue.component';
+import { EndShiftComponent } from './modals/end-shift/end-shift.component';
+import { PauseQueueComponent } from './modals/pause-queue/pause-queue.component';
+import { CallNotHappenedComponent } from './modals/call-not-happened/call-not-happened.component';
+import { CallDoneComponent } from './modals/call-done/call-done.component';
+import { SharedModule } from '../shared.module';
+
+// AoT requires an exported function for factories
+export function HttpLoaderFactory(httpClient: HttpClient) {
+  return new TranslateHttpLoader(httpClient, './assets/i18n/', '.json');
+}
+
+@NgModule({
+  declarations: [
+    QueueComponent,
+    EndShiftComponent,
+    PauseQueueComponent,
+    CallNotHappenedComponent,
+    CallDoneComponent
+  ],
+  imports: [
+    CommonModule,
+    FormsModule,
+    QueueRoutingModule,
+    MatTableModule,
+    MatMenuModule,
+    MatIconModule,
+    MatDialogModule,
+    MatTooltipModule,
+    MatButtonModule,
+    TranslateModule.forRoot({
+      loader: {
+        provide: TranslateLoader,
+        useFactory: HttpLoaderFactory,
+        deps: [HttpClient]
+      }
+    }),
+    SharedModule
+  ]
+})
+export class QueueModule { }

--- a/src/assets/svgs/menu-queue.svg
+++ b/src/assets/svgs/menu-queue.svg
@@ -1,0 +1,5 @@
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M7.5 2.5H12.5C13.0523 2.5 13.5 2.94772 13.5 3.5V4.5C13.5 5.05228 13.0523 5.5 12.5 5.5H7.5C6.94772 5.5 6.5 5.05228 6.5 4.5V3.5C6.5 2.94772 6.94772 2.5 7.5 2.5Z" stroke="white" stroke-width="1.4"/>
+<path d="M13.5 4H15.5C16.0523 4 16.5 4.44772 16.5 5V16.5C16.5 17.0523 16.0523 17.5 15.5 17.5H4.5C3.94772 17.5 3.5 17.0523 3.5 16.5V5C3.5 4.44772 3.94772 4 4.5 4H6.5" stroke="white" stroke-width="1.4" stroke-linecap="round"/>
+<path d="M7 9.5H13M7 13H11" stroke="white" stroke-width="1.4" stroke-linecap="round"/>
+</svg>

--- a/src/assets/svgs/queue-available.svg
+++ b/src/assets/svgs/queue-available.svg
@@ -1,0 +1,4 @@
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="10" cy="10" r="7" stroke="currentColor" stroke-width="1.6"/>
+<path d="M6.8 10.1L9 12.3L13.2 8.1" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/assets/svgs/queue-break.svg
+++ b/src/assets/svgs/queue-break.svg
@@ -1,0 +1,5 @@
+<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M5 13H21V21C21 24.3137 18.3137 27 15 27H11C7.68629 27 5 24.3137 5 21V13Z" stroke="#F0964B" stroke-width="2" stroke-linejoin="round"/>
+<path d="M21 15H23.5C25.433 15 27 16.567 27 18.5C27 20.433 25.433 22 23.5 22H21" stroke="#F0964B" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M10 5V8.5M15 5V8.5" stroke="#F0964B" stroke-width="2" stroke-linecap="round"/>
+</svg>

--- a/src/assets/svgs/queue-call-done.svg
+++ b/src/assets/svgs/queue-call-done.svg
@@ -1,0 +1,4 @@
+<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="16" cy="16" r="11" stroke="#2E1B87" stroke-width="2"/>
+<path d="M11 16.2L14.6 19.8L21.2 13.2" stroke="#2E1B87" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/assets/svgs/queue-call-missed.svg
+++ b/src/assets/svgs/queue-call-missed.svg
@@ -1,0 +1,4 @@
+<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M11.5 6.5L13.8 12.2L11 15C12.2 17.6 14.4 19.8 17 21L19.8 18.2L25.5 20.5V24C25.5 25.1 24.6 26 23.5 26C14.4 25.4 6.6 17.6 6 8.5C6 7.4 6.9 6.5 8 6.5H11.5Z" stroke="#5D6480" stroke-width="2" stroke-linejoin="round"/>
+<path d="M6 26L26 6" stroke="#5D6480" stroke-width="2" stroke-linecap="round"/>
+</svg>

--- a/src/assets/svgs/queue-end-shift.svg
+++ b/src/assets/svgs/queue-end-shift.svg
@@ -1,0 +1,5 @@
+<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M12 6H8C6.89543 6 6 6.89543 6 8V24C6 25.1046 6.89543 26 8 26H12" stroke="#5D6480" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M20 21L25 16L20 11" stroke="#5D6480" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M25 16H12" stroke="#5D6480" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -8,6 +8,7 @@ $breadcrumb-divider: url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iOCIgaGVpZ2h0
 @import 'bootstrap/scss/bootstrap.scss';
 @import "angular-calendar/css/angular-calendar.css";
 @import "./app/core/directives/mat-table-responsive.directive.scss";
+@import "./app/queue/queue-modals.scss";
 @import "@sjmc11/tourguidejs/src/scss/tour.scss";
 
 @font-face {


### PR DESCRIPTION
Add a Queue item to the doctor sidebar and a lazy-loaded /queue route
backed by a new QueueModule.

- Today's Queue table: patient, age, status, HW, location, chief
  complaint, with View Summary / Start actions and a kebab menu for
  View Details, Mark Call Done and Mark Call Did Not Happen
- Header availability toggle for available / on break / off shift
- Dialogs for End Shift, Pause Queue (10/20/30 min or custom),
  Call Did Not Happen (6 reasons) and Call Marked as Done

