### PR TITLE
feat(visit-summary): track WhatsApp, Kaleyra and patient contact events in Google Analytics

### DIFF
--- a/src/app/dashboard/visit-summary/visit-summary.component.html
+++ b/src/app/dashboard/visit-summary/visit-summary.component.html
@@ -102,7 +102,7 @@
                         target="_blank"
                         class="icon-btn"
                         data-test-id="linkWhatsApp"
-                        (click)="startWhatsAppCall(true)"
+                        (click)="onPatientWhatsAppClick(true)"
                       >
                         <img src="assets/svgs/whatsapp-icon.svg" alt="" />
                       </a>
@@ -111,6 +111,7 @@
                         target="_blank"
                         class="icon-btn"
                         data-test-id="linkPhoneNumber"
+                        (click)="onPatientPhoneClick()"
                       >
                         <img src="assets/svgs/phone-circle.svg" alt="" />
                       </a>

--- a/src/app/dashboard/visit-summary/visit-summary.component.ts
+++ b/src/app/dashboard/visit-summary/visit-summary.component.ts
@@ -1487,9 +1487,21 @@ export class VisitSummaryComponent implements OnInit, OnDestroy, AfterViewInit {
     const caller = doctorPhoneNumber ? doctorPhoneNumber : environment.doctorPhoneNumber;
     this.providerService.kaleyraClick2Call(caller, this.hwPhoneNo, custom, '0', notes).subscribe({
       next: (data) => {
+        this.analytics.logEvent('kaleyra_call_initiated', 'engagement', 'kaleyra_call_button', 1, {
+          doctorUserId: this.visitSummaryService.userId,
+          patientOpenMrsId: this.getPatientIdentifier('OpenMRS ID'),
+          visitId: visitUuid,
+          location: this.clinicName
+        });
         this.toastr.success('Kaleyra call initiated successfully. You will be connected to the health worker.');
       },
       error: (error) => {
+        this.analytics.logEvent('kaleyra_call_failed', 'engagement', 'kaleyra_call_button', 1, {
+          doctorUserId: this.visitSummaryService.userId,
+          visitId: visitUuid,
+          location: this.clinicName,
+          reason: error?.message ?? 'unknown'
+        });
         this.toastr.error('Failed to initiate Kaleyra call. Please try again.');
       }
     });
@@ -2947,11 +2959,45 @@ export class VisitSummaryComponent implements OnInit, OnDestroy, AfterViewInit {
     this.isCallInProgress = false;
     this.isWhatsappCallWarningShown = false;
     this.callTimerInterval.unsubscribe();
+    this.analytics.logEvent('whatsapp_call_ended', 'engagement', 'whatsapp_call_button', this.callDuration, {
+      doctorUserId: this.visitSummaryService.userId,
+      patientOpenMrsId: this.getPatientIdentifier('OpenMRS ID'),
+      visitId: this.visit?.uuid,
+      location: this.clinicName,
+      callDuration: this.callDuration
+    });
     this.arrCallDurations.push({ callDuration: this.callDuration, timestamp: this.callDurationTimeStamp })
     if (this.callDurationsUuid)
       this.visitService.updateAttribute(this.visit.uuid, this.callDurationsUuid, { attributeType: visitAttributeTypes.patientCallDuration, value: JSON.stringify(this.arrCallDurations) }).subscribe();
     else
       this.visitService.postAttribute(this.visit.uuid, { attributeType: visitAttributeTypes.patientCallDuration, value: JSON.stringify(this.arrCallDurations) }).subscribe();
+  }
+
+  contactAnalyticsPayload() {
+    return {
+      doctorUserId: this.visitSummaryService.userId,
+      patientOpenMrsId: this.getPatientIdentifier('OpenMRS ID'),
+      visitId: this.visit?.uuid,
+      location: this.clinicName
+    };
+  }
+
+  /**
+  * Track the patient WhatsApp icon, then start the timed call if enabled
+  * @param {boolean} isScroll - Scroll to the interaction form
+  * @returns {void}
+  */
+  onPatientWhatsAppClick(isScroll: boolean = false) {
+    this.analytics.logEvent('whatsapp_link_opened', 'engagement', 'patient_contact', 1, this.contactAnalyticsPayload());
+    this.startWhatsAppCall(isScroll);
+  }
+
+  /**
+  * Track the patient phone icon; the tel: href does the dialling
+  * @returns {void}
+  */
+  onPatientPhoneClick() {
+    this.analytics.logEvent('patient_phone_dialled', 'engagement', 'patient_contact', 1, this.contactAnalyticsPayload());
   }
 
   /**
@@ -2965,6 +3011,12 @@ export class VisitSummaryComponent implements OnInit, OnDestroy, AfterViewInit {
       if (!this.isCallInProgress) {
         this.isCallInProgress = true;
         this.callDurationTimeStamp = Date.now()
+        this.analytics.logEvent('whatsapp_call_started', 'engagement', 'whatsapp_call_button', 1, {
+          doctorUserId: this.visitSummaryService.userId,
+          patientOpenMrsId: this.getPatientIdentifier('OpenMRS ID'),
+          visitId: this.visit?.uuid,
+          location: this.clinicName
+        });
         this.callTimerInterval = interval(1000).subscribe(val => {
           this.callDuration = val;
         })


### PR DESCRIPTION
Adds GA4 events for the call actions that were not instrumented. Feeds the `Engagement (GA4)` section of the new cron microservice daily report, but stands on its own as analytics.

## Events added

| Event | Fires when |
| --- | --- |
| `kaleyra_call_initiated` | `kaleyraClick2Call` succeeds |
| `kaleyra_call_failed` | that request errors, with `reason` |
| `whatsapp_call_started` | timed WhatsApp call actually begins |
| `whatsapp_call_ended` | call ends, carries `callDuration` |
| `whatsapp_link_opened` | patient WhatsApp icon tapped |
| `patient_phone_dialled` | patient phone icon tapped |

All carry `doctorUserId`, `patientOpenMrsId`, `visitId` and `location`, matching the payload shape of the existing `start_call` event.

## Notes for review

**The patient phone icon had no click handler at all** — it was a bare `tel:` link, so those taps were invisible.

**`whatsapp_link_opened` is deliberately separate from `whatsapp_call_started`.** The latter fires inside `startWhatsAppCall()`, which is gated on `isFeatureAvailable('callDuration') && isVisitNoteProvider` and on no call already running — but the WhatsApp link opens regardless. Every tap outside those conditions was previously untracked. Keeping both gives a funnel, and the difference shows how often the feature gate suppresses the timer.

**Kaleyra fires on API success, not on click,** so failed attempts land in `kaleyra_call_failed` rather than inflating the initiated count.

Only `visit-summary` is touched. `visit-summary-v2` has no timed WhatsApp call or Kaleyra button — when those flows land there they will need the same handlers.

## Verification

`npx tsc --noEmit` reports 15 errors before and after this change, none in the touched file — all pre-existing (stale `dist/` artifacts and a spec duplicate).