### PR TITLE
feat: JSON format visit summary flag for AI LLM and aiddx-library v1.4.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "@ngx-translate/core": "^14.0.0",
         "@ngx-translate/http-loader": "^7.0.0",
         "@sjmc11/tourguidejs": "^0.0.17",
-        "aiddx-library": "github:Intelehealth/intelehealth-doctor-ddx-plugin#v1.3.8",
+        "aiddx-library": "github:Intelehealth/intelehealth-doctor-ddx-plugin#v1.4.1",
         "angular-calendar": "^0.29.0",
         "angular2-signaturepad": "^4.0.2",
         "bootstrap": "^4.6.2",
@@ -6455,8 +6455,8 @@
       }
     },
     "node_modules/aiddx-library": {
-      "version": "1.3.8",
-      "resolved": "git+ssh://git@github.com/Intelehealth/intelehealth-doctor-ddx-plugin.git#eed80639ad7dd00f1df69d6d41d1a818f19394a6",
+      "version": "1.4.1",
+      "resolved": "git+ssh://git@github.com/Intelehealth/intelehealth-doctor-ddx-plugin.git#0aaeeb7d7256ee11613c67bfbaf1ded30e7c8c41",
       "dependencies": {
         "tslib": "^2.3.0"
       },

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@ngx-translate/core": "^14.0.0",
     "@ngx-translate/http-loader": "^7.0.0",
     "@sjmc11/tourguidejs": "^0.0.17",
-    "aiddx-library": "github:Intelehealth/intelehealth-doctor-ddx-plugin#v1.3.8",
+    "aiddx-library": "github:Intelehealth/intelehealth-doctor-ddx-plugin#v1.4.1",
     "angular-calendar": "^0.29.0",
     "angular2-signaturepad": "^4.0.2",
     "bootstrap": "^4.6.2",

--- a/src/app/admin/admin-actions/ai-llm/ai-llm.component.html
+++ b/src/app/admin/admin-actions/ai-llm/ai-llm.component.html
@@ -55,21 +55,21 @@
                 </td>
               </ng-container> -->
 
-              <!-- <ng-container matColumnDef="is_enabled">
+              <ng-container matColumnDef="is_enabled">
                 <th mat-header-cell *matHeaderCellDef>
                   {{ "Active" | translate }}
                 </th>
                 <td mat-cell *matCellDef="let element">
                   <div class="tooltip-box">
                     <div class="pretty p-switch p-fill">
-                      <input type="checkbox" [checked]="element.is_enabled" (change)="updateAILLMEnabledStatus(element.id, $event.target.checked)" data-test-id="checkboxMindmapToggleStatus"/>
+                      <input type="checkbox" [checked]="element.is_enabled" (change)="updateAILLMEnabledStatus(element.id, $event.target.checked)" data-test-id="checkboxAILLMToggleStatus"/>
                       <div class="state">
                         <label></label>
                       </div>
                     </div>
                   </div>
                 </td>
-              </ng-container> -->
+              </ng-container>
 
               <tr class="mat-row" *matNoDataRow>
                 <td class="mat-cell text-center" [attr.colspan]="displayedAILLMColumns.length">{{ "No data to display." | translate }}</td>
@@ -81,6 +81,13 @@
           </div>
 
           <mat-paginator #aiLlmPaginator hidePageSize [pageSizeOptions]="[5, 10, 20]" showFirstLastButtons aria-label="Select page of periodic elements" data-test-id="matPaginatorAILLM"></mat-paginator>
+
+          <div class="ai-llm-note mt-3">
+            <img src="assets/svgs/alert-triangle.svg" alt="" class="alert-icon" />
+            <span>
+              {{ "When 'New JSON format visit summary' is active, the JSON version of the visit summary will be passed to the AI LLM APIs. Make sure the backend changes supporting this format are deployed before making it active." | translate }}
+            </span>
+          </div>
           <button type="button" class="btn-block mt-3" (click)="onPublish()" data-test-id="btnAddMindmap">
             {{ "Publish" | translate }}
           </button>

--- a/src/app/admin/admin-actions/ai-llm/ai-llm.component.scss
+++ b/src/app/admin/admin-actions/ai-llm/ai-llm.component.scss
@@ -243,3 +243,22 @@ th:last-child {
     flex-wrap: nowrap;
   }
 }
+
+.ai-llm-note {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 12px 14px;
+  border: 1px solid #f0c36d;
+  border-radius: 8px;
+  background: #fff8e6;
+  color: #6b5300;
+  font-size: 13px;
+  line-height: 1.5;
+
+  .alert-icon {
+    width: 20px;
+    height: 20px;
+    flex-shrink: 0;
+  }
+}

--- a/src/app/admin/admin-actions/ai-llm/ai-llm.component.ts
+++ b/src/app/admin/admin-actions/ai-llm/ai-llm.component.ts
@@ -23,7 +23,7 @@ export class AiLlmComponent {
 
   sectionEnabled: boolean = false;
   allSectionData: any = {};
-  displayedAILLMColumns: string[] = ["serialNo", "section"];
+  displayedAILLMColumns: string[] = ["serialNo", "section", "is_enabled"];
   displayedAILLMRecordingColumns: string[] = ["serialNo", "sectionr"];
 
   tableData = [];

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -50,7 +50,7 @@ import { MatBottomSheetModule } from '@angular/material/bottom-sheet';
 
 //Regular Imports
 import { environment } from "../environments/environment";
-import { ENVIRONMENT } from "aiddx-library";
+import { CONFIG_SERVICE, ENVIRONMENT } from "aiddx-library";
 import { SocketService } from "./services/socket.service";
 import { AppRoutingModule } from './app-routing.module';
 import { NetworkInterceptor } from "./core/interceptors/network.interceptor";
@@ -199,6 +199,7 @@ registerLocaleData(localeEn);
     CookieService,
     SocketService,
     { provide: ENVIRONMENT, useValue: environment },
+    { provide: CONFIG_SERVICE, useExisting: AppConfigService },
     { provide: APP_BASE_HREF, useValue: "/" },
     { provide: LocationStrategy, useClass: HashLocationStrategy },
     { provide: MAT_DIALOG_DATA, useValue: {} },

--- a/src/app/dashboard/visit-summary/diagnosis/diagnosis.component.ts
+++ b/src/app/dashboard/visit-summary/diagnosis/diagnosis.component.ts
@@ -8,7 +8,7 @@ import { MatTooltipModule } from '@angular/material/tooltip';
 import { NgSelectModule } from '@ng-select/ng-select';
 import { TranslateModule } from '@ngx-translate/core';
 import { Observable, of, Subject } from 'rxjs';
-import { AiddxLibraryModule, AiddxService, AiTxService, AillmddxComponent, AillmtxMedicationComponent, AillmtxAdviceComponent, AillmtxTestComponent, AillmtxFollowupComponent, AillmtxReferralComponent, ENVIRONMENT } from 'aiddx-library';
+import { AiddxLibraryModule, AiddxService, AiTxService, AillmddxComponent, AillmtxMedicationComponent, AillmtxAdviceComponent, AillmtxTestComponent, AillmtxFollowupComponent, AillmtxReferralComponent, ENVIRONMENT, CONFIG_SERVICE } from 'aiddx-library';
 import { getCacheData, isFeaturePresent } from 'src/app/utils/utility-functions';
 import { environment } from 'src/environments/environment';
 import { AppConfigService } from 'src/app/services/app-config.service';
@@ -86,6 +86,7 @@ class PickDateAdapter extends NativeDateAdapter {
     AiddxService,
     AiTxService,
     { provide: ENVIRONMENT, useValue: environment },
+    { provide: CONFIG_SERVICE, useExisting: AppConfigService },
     { provide: DateAdapter, useClass: PickDateAdapter },
     { provide: MAT_DATE_FORMATS, useValue: PICK_FORMATS }
   ],

--- a/src/app/services/app-config.service.ts
+++ b/src/app/services/app-config.service.ts
@@ -32,6 +32,7 @@ export class AppConfigService {
   public dropdown_values: DropdownValuesModel[]
   public patient_diagnostics_section: boolean;
   public ai_llm_section: boolean;
+  public ai_llm: { [key: string]: boolean };
   public ai_llm_recording_section:  boolean;
   public prescription_notes_section: boolean;
   public prescription_notes: { specialty: string; notes: string[]; is_enabled: boolean }[];


### PR DESCRIPTION
Bumps `aiddx-library` to **v1.4.1** and adds the admin flag that gates the new JSON visit-summary payload.

Depends on Intelehealth/intelehealth-doctor-ddx-plugin#3 (already published as `v1.4.1`) and the seeder in Intelehealth/intelehealth-backend-service#561.

## What changed

- `aiddx-library` pin `v1.4.0` → `v1.4.1`.
- **Admin → AI LLM**: the previously commented-out `is_enabled` **Active** toggle column is now live, so the new `New JSON format visit summary` row can be switched on. Added a warning note under the table.
- `AppConfigService` exposes `ai_llm: { [key: string]: boolean }`, populated by the existing `Object.assign(this, data)` in `load()`.
- Provides the library's `CONFIG_SERVICE` token with `AppConfigService`, in `app.module.ts` (root, for the v2 surface) and in `diagnosis.component.ts` providers (v1). Both are needed because the library module's own `{ provide: ENVIRONMENT, useValue: {} }` default shadows root providers — which is why `ENVIRONMENT` is already re-provided in that component.

The library reads the flag itself, so neither consumer surface gates it: no template bindings, and `visit-summary-v2.service.ts` is unchanged.

## Behaviour

Flag **off** (the seeded default) → the existing free-text payload, byte-for-byte unchanged. Flag **on** → the parsed `JSON Format Visit Summary` obs is sent as `casehistory`, with `notes` appended as an extra key for DDx. Visits without the obs fall back to the old payload.

## ⚠️ Do not enable the flag yet

`ai-middleware` types DDx `casehistory` and TTx `case` as `str` and validates for literal `Age:`, `Weight (kg):` and `Gender:` pairs, so sending the object returns 422. The admin note says as much.

## Testing

Ran against the **published** `v1.4.1` artifact resolved from `Intelehealth/intelehealth-doctor-ddx-plugin`, not the local dev symlink:

- `node_modules/aiddx-library` is a real folder at version `1.4.1`; lockfile resolves to commit `0aaeeb7d`
- installed files are byte-identical to the published branch (`diff -rq` against a fresh fetch)
- `ng serve` compiles clean; the served bundle contains the v1.4.1 API and none of the v1.4.0 `getAITTx(..., this.visit)` bug
- exactly **one** Angular Material copy in the bundle — no NG0203 duplicate-injector regression
